### PR TITLE
Brandy Austin - Matrix Convert - Octos

### DIFF
--- a/lib/matrix_convert_to_zero.rb
+++ b/lib/matrix_convert_to_zero.rb
@@ -2,6 +2,36 @@
 # Assumption/ Given: All numbers in the matrix are 0s or 1s
 # If any number is found to be 0, the method updates all the numbers in the
 # corresponding row as well as the corresponding column to be 0.
+require 'pry'
+
 def matrix_convert_to_0(matrix)
-  raise NotImplementedError
+
+  rows = matrix.size
+  columns = matrix[0].size
+  coordinates = []
+
+  rows.times do |row|
+
+    columns.times do |column|
+      if matrix[row][column] == 0
+        coordinates << [row, column]
+      end
+    end
+
+  end
+
+  coordinates.each do |x,y|
+
+    columns.times do |column|
+      matrix[x][column] = 0
+    end
+
+    rows.times do |row|
+      matrix[row][y] = 0
+    end
+
+  end
+
+  return matrix
+
 end


### PR DESCRIPTION
Time complexity - The first block has a time complexity of rows*columns. The second block has a time complexity of coordinates(rows*columns) where coordinates is whichever is shorter, columns or rows. This adds up to rows*columns + coordinates(rows  + columns). If we simplify the variables to n, this becomes n*n + (n*n)(n + n)  =  n^2 + n^3 + n^3  =  2(n^3) + n^2  =  2(n^3)  =  n^3. The (n*n) confused me initially, but coordinates needs to be described that way because it increases as the size of the matrix increases and the size of the matrix is determined by rows*columns. O(n^3) is the answer.

Space complexity - O(n^2) because coordinates is the main variable and the space needed to store that value is directly proportion to the number of elements in the matrix which is r*c or n^2.